### PR TITLE
Modify connectedToTheDom check to work correctly for elements owned b…

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,13 +64,9 @@ var backspaceCode = 8
         return false
     }
 
-    // returns true if the element
+    // returns true if the element is contained within a document
     function connectedToTheDom(node) {
-        while (node !== document && node.parentNode) {
-            node = node.parentNode
-        }
-
-        return node === document
+      return node.ownerDocument.contains(node);
     }
 
     function isActiveFormItem(node) {


### PR DESCRIPTION
…y documents other than the global document.

This fixes a bug that prevented the use of backspace in form elements (or content-editables) in secondary windows created using window.open.

Detached elements will still have the `ownerDocument` property, so this change still works for the use case addressed by #4.

Fixes #5.
